### PR TITLE
Add description about new token ORG_DATASOURCES:READ scope to avoid admin token use

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,15 @@ To deploy this template on Tinybird, click the following button:
 Access the Prometheus metrics endpoint at `https://api.tinybird.co/v0/pipes/organization_metrics.prometheus`.
 
 - Replace `api.tinybird.co` with your Tinybird host if the workspace is in a different region. See [Regions and endpoints](https://www.tinybird.co/docs/api-reference#regions-and-endpoints).
-- Use the `user@domain` admin token of an Organization admin to authenticate requests.
+- **Token**: for a quick check in development, you can use the pre-existing *admin `user@domain` Token* of an Organization admin to authenticate requests. But for production, the creation of a *new token* with less permissions is recommended, including these scopes:
+```
+  PIPES:READ:organization_metrics
+  ORG_DATASOURCES:READ
+```
+- As of this writing, the `ORG_DATASOURCES:READ` is not available from UI, but you can create this new **prometheus_org_access** token using tokens API like this:
+```shell
+POST https://api.tinybird.co/v0/tokens/?name=prometheus_org_access&description=optional&scope=PIPES:READ:organization_metrics&scope=ORG_DATASOURCES:READ
+```
 
 To scrape the Tinybird metrics endpoint, you can configure your `prometheus.yml` file as follows:
 

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -22,7 +22,15 @@ scrape_configs:
 
 
 - Replace `api.tinybird.co` with your Tinybird host if the workspace is in a different region. See [Regions and endpoints](https://www.tinybird.co/docs/api-reference#regions-and-endpoints).  
-- Use `admin user@domain Token` of an Organization admin to authenticate requests. Find it in the [Tinybird dashboard](https://app.tinybird.co/tokens).
+- **Token**: for a quick check in development, you can use the pre-existing *admin `user@domain` Token* of an Organization admin to authenticate requests (find it in the [Tinybird dashboard](https://app.tinybird.co/tokens)). But for production, the creation of a *new token* with less permissions is recommended, including these scopes:
+```
+  PIPES:READ:organization_metrics
+  ORG_DATASOURCES:READ
+```
+- As of this writing, the `ORG_DATASOURCES:READ` is not available from UI, but you can create this new **prometheus_org_access** token using tokens API like this:
+```shell
+POST https://api.tinybird.co/v0/tokens/?name=prometheus_org_access&description=optional&scope=PIPES:READ:organization_metrics&scope=ORG_DATASOURCES:READ
+```
 
 We've included a sample dashboard config for Grafana to help you get started, see the [JSON file](https://github.com/tinybirdco/tinybird-org-metrics-exporter/blob/main/grafana/tinybird_org_metrics.json).
 


### PR DESCRIPTION
The new scope is already in place in the platform (https://gitlab.com/tinybird/analytics/-/merge_requests/16113), allowing a safer use of this template